### PR TITLE
Replace Scan with Query

### DIFF
--- a/lib/shoryuken/later/client.rb
+++ b/lib/shoryuken/later/client.rb
@@ -45,25 +45,23 @@ module Shoryuken
           # Mostly for record keeping
           item['id'] = SecureRandom.uuid
 
-          params = {
+          ddb.put_item({
             table_name: table,
-            item: table,
+            item: item,
             # condition_expression: "" # TODO `expected` is deprecated
             # expected: { perform_at: { exists: false } }
-          }
+          })
         end
 
         def delete_item(table, item)
-          params = {
+          ddb.delete_item({
             table_name: table,
             key: {
               scheduler: item['scheduler'],
               perform_at: item['perform_at']
             },
             # expected: { perform_at: { value: item['perform_at'], exists: true } } # TODO Deprecated
-          }
-
-          ddb.delete_item(params)
+          })
         end
 
         def ddb

--- a/lib/shoryuken/later/client.rb
+++ b/lib/shoryuken/later/client.rb
@@ -20,15 +20,40 @@ module Shoryuken
         end
         
         def create_item(table, item)
-          item['id'] ||= SecureRandom.uuid
-          
-          ddb.put_item(table_name: table, item: item,
-                       expected: {id: {exists: false}})
+          # Items are intended for tables with hash+range primary keys. The
+          # `scheduler` hash key is essentially meaningless, it but a hash key
+          # is required. By having a meaningful range key that can also provide
+          # uniqueness, querying for pending items is fairly efficient.
+
+          item['scheduler'] = 'shoryuken-later'
+
+          # Add a random fraction to maintain unique range keys for jobs with
+          # a single second
+          # (DynamoDB take Number values as Strings to avoid precision issues)
+          item['perform_at'] = "#{item['perform_at']}.#{Random.rand(2 ** 64)}"
+
+          # Mostly for record keeping
+          item['id'] = SecureRandom.uuid
+
+          params = {
+            table_name: table,
+            item: table,
+            # condition_expression: "" # TODO `expected` is deprecated
+            # expected: { perform_at: { exists: false } }
+          }
         end
         
         def delete_item(table, item)
-          ddb.delete_item(table_name: table, key: {id: item['id']},
-                          expected: {id: {value: item['id'], exists: true}})
+          params = {
+            table_name: table,
+            key: {
+              scheduler: item['scheduler'],
+              perform_at: item['perform_at']
+            },
+            # expected: { perform_at: { value: item['perform_at'], exists: true } } # TODO Deprecated
+          }
+
+          ddb.delete_item(params)
         end
         
         def ddb

--- a/lib/shoryuken/later/poller.rb
+++ b/lib/shoryuken/later/poller.rb
@@ -4,30 +4,31 @@ module Shoryuken
   module Later
     class Poller
       include Shoryuken::Util
-      
+
       attr_reader :table_name
-      
+
       def initialize(table_name)
         @table_name = table_name
       end
-      
+
       def poll
         watchdog('Later::Poller#poll died') do
           started_at = Time.now
-          
+
           logger.debug { "Polling for scheduled messages in '#{table_name}'" }
-          
+
           begin
-            while item = next_item
-              id = item['id']
-              logger.info "Found message #{id} from '#{table_name}'"
+            client.items.each do |item|
+              logger.info "Found message #{item['id']} from '#{table_name}'"
+
+              # TODO Should be able to process these in batches of 10
               if sent_msg = process_item(item)
                 logger.debug { "Enqueued message #{id} from '#{table_name}'" }
               else
                 logger.debug { "Skipping already queued message #{id} from '#{table_name}'" }
               end
             end
-  
+
             logger.debug { "Poller for '#{table_name}' completed in #{elapsed(started_at)} ms" }
           rescue => ex
             logger.error "Error fetching message: #{ex}"
@@ -37,28 +38,20 @@ module Shoryuken
       end
 
     private
-    
+
       def client
         Shoryuken::Later::Client
       end
-    
-      # Fetches the next available item from the schedule table.    
-      def next_item
-        client.first_item table_name, 'perform_at' => {
-                attribute_value_list: [ (Time.now + Shoryuken::Later::MAX_QUEUE_DELAY).to_i ],
-                comparison_operator:  'LT'
-              }
-      end
-    
+
       # Processes an item and enqueues it (unless another actor has already enqueued it).
       def process_item(item)
         time, worker_class, args, id = item.values_at('perform_at','shoryuken_class','shoryuken_args','id')
-        
+
         worker_class = worker_class.constantize
         args = JSON.parse(args)
         time = Time.at(time)
         queue_name = item['shoryuken_queue']
-        
+
         # Conditionally delete an item prior to enqueuing it, ensuring only one actor may enqueue it.
         begin client.delete_item table_name, item
         rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException => e
@@ -70,7 +63,7 @@ module Shoryuken
         body, options = args.values_at('body','options')
         if queue_name.nil?
           worker_class.perform_in(time, body, options)
-          
+
         # For compatibility with Shoryuken's ActiveJob adapter, support an explicit queue name.
         else
           delay = (time - Time.now).to_i

--- a/lib/shoryuken/later/poller.rb
+++ b/lib/shoryuken/later/poller.rb
@@ -34,13 +34,19 @@ module Shoryuken
       end
 
       def process_items(items)
-        # Pre-process items to determine if they should be enqueued
-        entries = items.map{ |item| preprocess_item(item) }.compact
+        entries = preprocess_items(items)
 
         # Enqueue the batch of messages for viable items
-        Shoryuken::Client.queues(queue_name).send_messages(entries)
+        if entries.count > 0
+          Shoryuken::Client.queues(queue_name).send_messages(entries)
+        end
 
         logger.debug { "Enqueued #{entries.count} of #{items.count} messages from '#{table_name}'" }
+      end
+
+      # Returns a set of message options (entities) that can be enqueued
+      def preprocess_items(items)
+        items.map{ |item| preprocess_item(item) }.compact
       end
 
       # Pre-processes an item (unless another actor has already enqueued it),

--- a/spec/shoryuken/later/client_spec.rb
+++ b/spec/shoryuken/later/client_spec.rb
@@ -18,18 +18,13 @@ describe Shoryuken::Later::Client do
       expect(described_class.tables(table)).to eq(table_description)
     end
   end
-  
+
   describe '.create_item' do
-    it 'creates an item with a supplied ID' do
-      expect(ddb).to receive(:put_item).with(table_name: table, item: {'id' => 'fubar'}, expected: {id: {exists: false}})
-        
-      described_class.create_item(table,'id' => 'fubar')
-    end
-    
-    it 'creates an item with a auto-generated ID' do
+    it 'creates an item with unique hash and range key' do
       expect(SecureRandom).to receive(:uuid).once.and_return('fubar')
-      expect(ddb).to receive(:put_item).with(table_name: table, item: {'id' => 'fubar', 'perform_at' => 1234}, expected: {id: {exists: false}})
-        
+      expect(Random).to receive(:rand).once.and_return(5678)
+      expect(ddb).to receive(:put_item).with(table_name: table, item: {'id' => 'fubar', 'perform_at' => '1234.5678', 'scheduler' => 'shoryuken-later'})
+
       described_class.create_item(table,'perform_at' => 1234)
     end
   end


### PR DESCRIPTION
Based on the reading I've been doing on DynamoDB, it looks like Query operations are much more ideal/efficient than Scan operations. Since DDB supports range type keys, and that fits very well with the needs of this kind of polling, taking advantage of Query seems like a good approach. It's a little goofy that every item will have the same primary key hash value, but I couldn't find anything that indicates it's actually a bad idea in practice. It's a little more weird using fractional seconds to keep all the items' PK's unique, but I think statistically it is fairly sound.

**This is all totally untested**; just something I wanted to get down on paper while I was reading through the docs. Curious to see if anyone thinks this is a good path to keep going down, though. It handles #6 without having to just scan the entire table on every request, which is what will need to happen if Scan continues to be used.
