### PR TITLE
Fix wait_interval.  Cannot be Negative

### DIFF
--- a/lib/shoryuken/later/cli.rb
+++ b/lib/shoryuken/later/cli.rb
@@ -65,7 +65,7 @@ module Shoryuken
           
           # Loop watching for signals and firing off of timers
           while @timers
-            interval = @timers.wait_interval
+            interval = @timers.wait_interval.abs
             readable, writable = IO.select([@self_read], nil, nil, interval)
             if readable
               handle_signal readable.first.gets.strip


### PR DESCRIPTION
Joe,
We ran into this problem when we started using Shoryuken-later a few months ago.  In certain instances, the wait_interval value can be negative.  When this happens, the next line which receives the value, "IO.select", throws an error which causes the process to stop.  

We considered a few different things when approaching this issue and settled on simply taking the absolute value of the wait interval in order to ensure that the value is a positive number.  Since we manually changed this, things have been very stable in our Production environment.

We are open to other ideas and suggestions, but if this fix seems logically, we were hoping that you could merge it into master.  

Thanks for your help on this.
Jon
