### PR TITLE
Feature/aws instance profile credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+  - 2.3.0
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ aws:
   secret_access_key:  ...       # or <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region:             us-east-1 # or <%= ENV['AWS_REGION'] %>
 logfile: some/path/to/file.log
-  
+
 # This key is only used by Shoryuken::Later
 later:
   delay: 5 * 60   # How frequently to poll the schedule table, in seconds.
@@ -62,7 +62,7 @@ Start the `shoryuken-later` schedule poller with a command like:
 bundle exec shoryuken-later --config shoryuken.yml
 ```
 
-Run it as a daemon inside of your Rails app with a command like: 
+Run it as a daemon inside of your Rails app with a command like:
 
 ```shell
 bundle exec shoryuken-later --config shoryuken.yml --rails --daemon
@@ -82,9 +82,12 @@ config.active_job.queue_adapter = :shoryuken_later
 
 When you use the `:shoryuken_later` queue adapter, jobs to be performed farther than 15 minutes into the future (by setting the `wait` or `wait_until` ActiveJob options), will be inserted into the *default* schedule table.  You can set the default schedule table in an initializer.
 
+You can also reuse ActiveJob's default prefix for job as prefix for the table names
+
 ```ruby
 # config/initializers/shoryuken_later.rb
-Shoryuken::Later.default_table = "#{Rails.env}_myapp_later"
+Shoryuken::Later.default_table = "shoryuken_later"
+Shoryuken::Later.active_job_table_name_prefixing = true
 ```
 
 
@@ -97,7 +100,7 @@ A new method named `perform_later` is added to `Shoryuken::Worker` allowing mess
 
  class MyWorker
    include Shoryuken::Worker
-  
+
    shoryuken_options queue: 'default', schedule_table: 'default_schedule'
  end
 
@@ -131,7 +134,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install shoryuken-later
-    
+
 ## Documentation
 
 Learn about using Shoryuken::Later at the [Shoryuken::Later Wiki](https://github.com/joekhoobyar/shoryuken-later/wiki).

--- a/lib/shoryuken/later.rb
+++ b/lib/shoryuken/later.rb
@@ -6,9 +6,9 @@ require 'shoryuken/later/worker'
 module Shoryuken
   module Later
     MAX_QUEUE_DELAY = 15 * 60
-    
+
     DEFAULT_POLL_DELAY = 5 * 60
-    
+
     DEFAULTS = {
       aws: {},
       later: {
@@ -17,33 +17,63 @@ module Shoryuken
       },
       timeout: 8
     }
-    
+
     @@tables = []
     @@default_table = 'shoryuken_later'
-    
+    @@active_job_table_name_prefixing = false
+
     class << self
+
       def options
         @options ||= DEFAULTS.dup.tap{|h| h[:later] = h[:later].dup }
       end
-      
+
       def poll_delay
         options[:later][:delay] || DEFAULT_POLL_DELAY
       end
-      
+
+      def logger
+        Shoryuken::Logging.logger
+      end
+
+      # Assume whole configuration was loaded, perform extra steps such as prefixing table names
+      def process_options
+        prefix_table_names
+      end
+
       def default_table
         @@default_table
       end
-      
+
       def default_table=(table)
         @@default_table = table
       end
-      
+
       def tables
         @@tables
       end
-    
-      def logger
-        Shoryuken::Logging.logger
+
+      def active_job_table_name_prefixing
+        @@active_job_table_name_prefixing
+      end
+
+      def active_job_table_name_prefixing=(prefix)
+        @@active_job_table_name_prefixing = prefix
+      end
+
+      def prefix_table_names
+        return unless defined? ::ActiveJob
+        return unless Shoryuken::Later.active_job_table_name_prefixing
+
+        # Note : use the same prefix used for the ActiveJob queues, seems legit
+        table_name_prefix = ::ActiveJob::Base.queue_name_prefix
+        table_name_delimiter = ::ActiveJob::Base.queue_name_delimiter
+
+        # See https://github.com/rails/rails/blob/master/activejob/lib/active_job/queue_name.rb#L27
+        Shoryuken::Later.tables.map! do |table_name, weight|
+          name_parts = [table_name_prefix, table_name]
+          name_parts.compact.join(table_name_delimiter)
+        end
       end
     end
   end

--- a/lib/shoryuken/later/cli.rb
+++ b/lib/shoryuken/later/cli.rb
@@ -34,15 +34,15 @@ module Shoryuken
         validate!
         daemonize
         write_pid
-        
+
         Shoryuken::Logging.with_context '[later]' do
           logger.info 'Starting'
           start
         end
       end
-      
+
       protected
-      
+
       def poll_tables
         logger.debug "Polling schedule tables"
         @pollers.each do |poller|
@@ -52,17 +52,17 @@ module Shoryuken
       end
 
       private
-      
+
       def start
         # Initialize the timers and poller.
         @timers = Timers::Group.new
         @pollers = Shoryuken::Later.tables.map{|tbl| Poller.new(tbl) }
-          
+
         begin
           # Poll for items on startup, and every :poll_delay
           poll_tables
           @timers.every(Shoryuken::Later.poll_delay){ poll_tables }
-          
+
           # Loop watching for signals and firing off of timers
           while @timers
             interval = @timers.wait_interval
@@ -216,14 +216,17 @@ module Shoryuken
 
         Shoryuken::Later.options[:later].merge!(options.delete(:later) || {})
         Shoryuken::Later.options.merge!(options)
-        
+
+        # Extra processing from config : prefixes, etc.
+        Shoryuken::Later.process_options
+
         # Tables from command line options take precedence...
         unless Shoryuken::Later.tables.any?
           tables = Shoryuken::Later.options[:later][:tables]
 
           # Use the default table if none were specified in the config file.
           tables << Shoryuken::Later.default_table if tables.empty?
-          
+
           Shoryuken::Later.tables.replace(tables)
         end
       end
@@ -245,6 +248,7 @@ module Shoryuken
       def validate!
         raise ArgumentError, 'No tables given to poll' if Shoryuken::Later.tables.empty?
 
+        # TODO : SHoryuken 3 no longer uses aws from config file
         if Shoryuken::Later.options[:aws][:access_key_id].nil? && Shoryuken::Later.options[:aws][:secret_access_key].nil?
           if ENV['AWS_ACCESS_KEY_ID'].nil? && ENV['AWS_SECRET_ACCESS_KEY'].nil?
             raise ArgumentError, 'No AWS credentials supplied'
@@ -267,21 +271,21 @@ module Shoryuken
         # aws-sdk tries to load the credentials from the ENV variables: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
         # when not explicit supplied
         return if Shoryuken::Later.options[:aws].empty?
-  
+
         shoryuken_keys = %i(
           account_id
           sns_endpoint
           sqs_endpoint
           receive_message)
-  
+
         aws_options = Shoryuken::Later.options[:aws].reject do |k, v|
           shoryuken_keys.include?(k)
         end
-  
+
         credentials = Aws::Credentials.new(
           aws_options.delete(:access_key_id),
           aws_options.delete(:secret_access_key))
-  
+
         Aws.config = aws_options.merge(credentials: credentials)
       end
 

--- a/lib/shoryuken/later/poller.rb
+++ b/lib/shoryuken/later/poller.rb
@@ -4,61 +4,59 @@ module Shoryuken
   module Later
     class Poller
       include Shoryuken::Util
-      
+
       attr_reader :table_name
-      
+
       def initialize(table_name)
         @table_name = table_name
       end
-      
+
       def poll
-        watchdog('Later::Poller#poll died') do
-          started_at = Time.now
-          
-          logger.debug { "Polling for scheduled messages in '#{table_name}'" }
-          
-          begin
-            while item = next_item
-              id = item['id']
-              logger.info "Found message #{id} from '#{table_name}'"
-              if sent_msg = process_item(item)
-                logger.debug { "Enqueued message #{id} from '#{table_name}'" }
-              else
-                logger.debug { "Skipping already queued message #{id} from '#{table_name}'" }
-              end
+        started_at = Time.now
+
+        logger.debug { "Polling for scheduled messages in '#{table_name}'" }
+
+        begin
+          while item = next_item
+            id = item['id']
+            logger.info "Found message #{id} from '#{table_name}'"
+            if sent_msg = process_item(item)
+              logger.debug { "Enqueued message #{id} from '#{table_name}'" }
+            else
+              logger.debug { "Skipping already queued message #{id} from '#{table_name}'" }
             end
-  
-            logger.debug { "Poller for '#{table_name}' completed in #{elapsed(started_at)} ms" }
-          rescue => ex
-            logger.error "Error fetching message: #{ex}"
-            logger.error ex.backtrace.first
           end
+
+          logger.debug { "Poller for '#{table_name}' completed in #{elapsed(started_at)} ms" }
+        rescue => ex
+          logger.error "Error fetching message: #{ex}"
+          logger.error ex.backtrace.first
         end
       end
 
     private
-    
+
       def client
         Shoryuken::Later::Client
       end
-    
-      # Fetches the next available item from the schedule table.    
+
+      # Fetches the next available item from the schedule table.
       def next_item
         client.first_item table_name, 'perform_at' => {
                 attribute_value_list: [ (Time.now + Shoryuken::Later::MAX_QUEUE_DELAY).to_i ],
                 comparison_operator:  'LT'
               }
       end
-    
+
       # Processes an item and enqueues it (unless another actor has already enqueued it).
       def process_item(item)
         time, worker_class, args, id = item.values_at('perform_at','shoryuken_class','shoryuken_args','id')
-        
+
         worker_class = worker_class.constantize
         args = JSON.parse(args)
         time = Time.at(time)
         queue_name = item['shoryuken_queue']
-        
+
         # Conditionally delete an item prior to enqueuing it, ensuring only one actor may enqueue it.
         begin client.delete_item table_name, item
         rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException => e
@@ -70,7 +68,7 @@ module Shoryuken
         body, options = args.values_at('body','options')
         if queue_name.nil?
           worker_class.perform_in(time, body, options)
-          
+
         # For compatibility with Shoryuken's ActiveJob adapter, support an explicit queue name.
         else
           delay = (time - Time.now).to_i

--- a/lib/shoryuken/later/version.rb
+++ b/lib/shoryuken/later/version.rb
@@ -1,5 +1,5 @@
 module Shoryuken
   module Later
-    VERSION = '0.1.3'
+    VERSION = '0.2.0'
   end
 end

--- a/lib/shoryuken/later/version.rb
+++ b/lib/shoryuken/later/version.rb
@@ -1,5 +1,5 @@
 module Shoryuken
   module Later
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/shoryuken-later.gemspec
+++ b/shoryuken-later.gemspec
@@ -13,20 +13,20 @@ Gem::Specification.new do |spec|
   spec.description = %Q{
     This gem provides a scheduling plugin (using Dynamo DB) for Shoryuken, as well as an ActiveJob adapter
   }
-  
+
   spec.license = "LGPL-3.0"
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables = %w[shoryuken-later]
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.required_ruby_version = '>= 2.0.0'
-  
+
   spec.add_development_dependency "bundler", '>= 1.3.5'
   spec.add_development_dependency "rake",    '~> 10.0'
   spec.add_development_dependency "rspec",   '~> 3.0', '< 3.1'
   spec.add_development_dependency "pry-byebug"
 
   spec.add_dependency "timers", "~> 4.0.1"
-  spec.add_dependency "shoryuken", "~> 1.0.0"
+  spec.add_dependency "shoryuken", "~> 3.0"
 end

--- a/spec/shoryuken/later/environment_spec.rb
+++ b/spec/shoryuken/later/environment_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'Shoryuken::EnvironmentLoader' do
+  let(:tables)     { ['shoryuken_later'] }
+  let(:active_support_prefix)     { 'active_support_prefix_test' }
+  let(:active_support_delimiter)     { '_' }
+
+  before(:all) do
+    @original_tables = Shoryuken::Later.class_variable_get :@@tables
+    @original_prefix_config = Shoryuken::Later.active_job_table_name_prefixing = true
+  end
+
+  before(:each) do
+    Shoryuken::Later.class_variable_set :@@tables, tables
+    Shoryuken::Later.active_job_table_name_prefixing = true
+  end
+
+  describe 'ActiveJob integration' do
+    it 'Prefixes table names with ActiveJob Queue Prefix' do
+      stub_const('ActiveJob::Base', Class.new)
+      expect(ActiveJob::Base).to receive(:queue_name_prefix).and_return(active_support_prefix)
+      expect(ActiveJob::Base).to receive(:queue_name_delimiter).and_return(active_support_delimiter)
+      Shoryuken::Later.process_options
+      expect(Shoryuken::Later.tables.first).to eq('active_support_prefix_test_shoryuken_later')
+    end
+  end
+
+  after(:all) do
+    Shoryuken::Later.class_variable_set :@@tables, @original_tables
+    Shoryuken::Later.active_job_table_name_prefixing = @original_prefix_config
+  end
+end


### PR DESCRIPTION
The current version of Shoryuken later does not support instance profile credentials (from instance metadata service)

Actually, I am not sure how credentials are handled by other gems, and I don't think their presence should be checked at all...

Checking for instance profile credentials with Aws::InstanceProfileCredentials.new can be quite long (few secs) event with a single retry, I'm not really satisfied by this but it's better than nothing